### PR TITLE
Update Ubuntu Provisioning

### DIFF
--- a/playbooks/provision_ubuntu.yml
+++ b/playbooks/provision_ubuntu.yml
@@ -5,9 +5,9 @@
     - etckeeper/ubuntu
     - base_packages/ubuntu
     - base_snap/ubuntu
+    - gnome/ubuntu
     - grub/ubuntu
     - nextcloud/ubuntu
     - hardening/ubuntu
     - chrony/ubuntu
-    - dnsmasq/ubuntu
     - user/ubuntu


### PR DESCRIPTION
- Move to default gnome looks by default again