### PR TITLE
Set default branch to main

### DIFF
--- a/roles/etckeeper/tasks/main.yml
+++ b/roles/etckeeper/tasks/main.yml
@@ -17,6 +17,8 @@
         email = root@localhost
       [push]
         default = simple
+      [init]
+        defaultBranch = main
   when: not stat_gitconfig.stat.exists
 
 - name: install etckeeper for Debian based systems

--- a/roles/user/templates/gitconfig.j2
+++ b/roles/user/templates/gitconfig.j2
@@ -10,3 +10,5 @@
 	ff = only
 [push]
 	default = simple
+[init]
+	defaultBranch = main


### PR DESCRIPTION
Configure 'main' to be the default git branch, configured in gitconfig itself.