### PR TITLE
Update vscode settings.json

### DIFF
--- a/roles/vscode/files/settings.json
+++ b/roles/vscode/files/settings.json
@@ -10,17 +10,7 @@
     "window.autoDetectColorScheme": true,
     "git.enableCommitSigning": true,
     "git.confirmSync": false,
-    "editor.rulers": [
-        {
-            "column": 80,
-            "color": "#ff00FF"
-        },
-        100,
-        {
-            "column": "120",
-            "color": "#ff0000"
-        }
-    ],
+    "editor.rulers": [80, 100, 120],
     "[yaml]": {
         "editor.insertSpaces": true,
         "editor.tabSize": 2,


### PR DESCRIPTION
Update vscode `settings.json` to set editor rules using the colours of the vscode theme.