### PR TITLE
Update stuff

### DIFF
--- a/roles/kitty/files/kitty.conf
+++ b/roles/kitty/files/kitty.conf
@@ -1,5 +1,5 @@
 # Generic kitty config file
-include themes/brogrammer.conf
+include themes/solarized-light.conf
 include fonts.conf
 include tab_bar.conf
 include generic.conf

--- a/roles/libinput/files/touchegg.conf
+++ b/roles/libinput/files/touchegg.conf
@@ -78,18 +78,20 @@
     </gesture>
 
     <gesture type="SWIPE" fingers="4" direction="UP">
-      <action type="CHANGE_DESKTOP">
-        <direction>auto</direction>
-        <animate>true</animate>
-        <animationPosition>up</animationPosition>
+      <action type="SEND_KEYS">
+        <repeat>false</repeat>
+        <modifiers>Control_L</modifiers>
+        <keys>F8</keys>
+        <on>begin</on>
       </action>
     </gesture>
 
     <gesture type="SWIPE" fingers="4" direction="DOWN">
-      <action type="CHANGE_DESKTOP">
-        <direction>auto</direction>
-        <animate>true</animate>
-        <animationPosition>down</animationPosition>
+      <action type="SEND_KEYS">
+        <repeat>false</repeat>
+        <modifiers>Control_L</modifiers>
+        <keys>F8</keys>
+        <on>begin</on>
       </action>
     </gesture>
 

--- a/roles/libinput/tasks/libinput_debian.yml
+++ b/roles/libinput/tasks/libinput_debian.yml
@@ -10,4 +10,4 @@
 
 - name: Install touchegg
   ansible.builtin.apt:
-    deb: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.3/touchegg_2.0.3_amd64.deb'
+    deb: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.7/touchegg_2.0.7_amd64.deb'

--- a/roles/libinput/tasks/libinput_fedora.yml
+++ b/roles/libinput/tasks/libinput_fedora.yml
@@ -11,6 +11,6 @@
 
 - name: Install touchegg
   ansible.builtin.dnf:
-    name: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.3/touchegg-2.0.3-1.x86_64.rpm'
+    name: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.7/touchegg-2.0.7-1.x86_64.rpm'
     state: present
     disable_gpg_check: yes


### PR DESCRIPTION
- Set kitty colourscheme to solarized light
- Update touchegg config to allow desktop overview
- Bump touchegg to 2.0.7 for Debian and Fedora based