### PR TITLE
Update touchegg and pulseaudio

### DIFF
--- a/roles/libinput/tasks/libinput_debian.yml
+++ b/roles/libinput/tasks/libinput_debian.yml
@@ -1,13 +1,11 @@
 ---
 
+- name: Add touchegg repository and add its signing key
+  ansible.builtin.apt_repository:
+    repo: ppa:touchegg/stable
+
 - name: Install libinput package requirements
   ansible.builtin.apt:
-    pkg:
-      - build-essential
-      - libinput-tools
-      - ruby
-      - wmctrl
-
-- name: Install touchegg
-  ansible.builtin.apt:
-    deb: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.7/touchegg_2.0.7_amd64.deb'
+    name: touchegg
+    state: latest
+    update_cache: yes

--- a/roles/libinput/tasks/libinput_fedora.yml
+++ b/roles/libinput/tasks/libinput_fedora.yml
@@ -11,6 +11,6 @@
 
 - name: Install touchegg
   ansible.builtin.dnf:
-    name: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.7/touchegg-2.0.7-1.x86_64.rpm'
+    name: 'https://github.com/JoseExposito/touchegg/releases/download/2.0.9/touchegg-2.0.9-1.x86_64.rpm'
     state: present
     disable_gpg_check: yes

--- a/roles/pulseaudio/tasks/main.yml
+++ b/roles/pulseaudio/tasks/main.yml
@@ -7,4 +7,4 @@
     replace: 'load-module module-udev-detect tsched=0'
   notify:
     - Restart pulseaudio
-  when: desktop_environment != "none"
+  when: desktop_environment != "none" and ansible_distribution != 'Fedora'


### PR DESCRIPTION
Fedora changes:
  - Install the latest touchegg RPM
  - Don't apply pulseaudio configuration (F34 uses pipewire by default
    now)

Ubuntu/Debian changes:
  - Instead of installing the touchegg deb file directly, add the
    official PPA and ensure touchegg is the latest version installed