### PR TITLE
Update apt tmp config

### DIFF
--- a/roles/hardening/files/apt_00exectmp
+++ b/roles/hardening/files/apt_00exectmp
@@ -1,0 +1,4 @@
+# mount /tmp with exec before running dpkg commands
+# mount /tmp noexec when dpkg is done
+DPkg::Pre-Invoke {"mount -o remount,exec /tmp";}
+DPkg::Post-Invoke {"mount -o remount /tmp";}

--- a/roles/hardening/tasks/tmp_debian.yml
+++ b/roles/hardening/tasks/tmp_debian.yml
@@ -19,3 +19,14 @@
     masked: no
   notify:
     - Manually remount /tmp with noexec permissions
+
+- name: Configure apt to remount tmp with exec permissions
+  ansible.builtin.copy:
+    src: apt_00exectmp
+    dest: /etc/apt/apt.conf.d/apt_00exectmp
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Ensure all handlers (up until now) are run
+  meta: flush_handlers


### PR DESCRIPTION
- Configure apt to remount tmp if required
- Tell handlers to run and not wait till end of play when remounting
  /tmp

Signed-off-by: Jeffrey Bouter <jb@warpnet.nl>